### PR TITLE
Update config.json

### DIFF
--- a/config/DS920+/7.0.1-42218/config.json
+++ b/config/DS920+/7.0.1-42218/config.json
@@ -2,7 +2,7 @@
   "os": {
     "id": "ds920p_42218",
     "pat_url": "https://global.download.synology.com/download/DSM/release/7.0.1/42218/DSM_DS920%2B_42218.pat",
-    "sha256": "fe2a4648f76adeb65c3230632503ea36bbac64ee88b459eb9bfb5f3b8c8cebb3"
+    "sha256": "b9b77846e0983f50496276bec6bcdfcfadd4c1f9f0db8ed2ca5766f131ddf97f"
   },
 
   "files": {


### PR DESCRIPTION
I have compute checksum on file downloaded by browser and it fits with computed checksum shown below:

[#] PAT file /home/tc/redpill-load/cache/ds920p_42218.pat not found - downloading from https://global.download.synology.com/download/DSM/release/7.0.1/42218/DSM_DS920%2B_42218.pat
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  397M  100  397M    0     0  19.7M      0  0:00:20  0:00:20 --:--:-- 23.8M
[#] Verifying /home/tc/redpill-load/cache/ds920p_42218.pat file... [ERR]
[!] Checksum mismatch - expected fe2a4648f76adeb65c3230632503ea36bbac64ee88b459eb9bfb5f3b8c8cebb3 but computed b9b77846e0983f50496276bec6bcdfcfadd4c1f9f0db8ed2ca5766f131ddf97f