### PR TITLE
fix: use -BM flag with df to avoid float comparison

### DIFF
--- a/rploader.sh
+++ b/rploader.sh
@@ -3188,7 +3188,7 @@ function buildloader() {
     echo "Caching files for future use"
     [ ! -d ${local_cache} ] && mkdir ${local_cache}
 
-    if [ $(df -h /mnt/${tcrppart} | grep mnt | awk '{print $4}' | sed -e 's/M//g' -e 's/G//g' | cut -c 1-3) -le 400 ]; then
+    if [ $(df -h -BM /mnt/${tcrppart} | grep mnt | awk '{print $4}' | sed -e 's/M//g') -le 400 ]; then
         echo "No adequate space on TCRP loader partition /mnt/${tcrppart} to cache pat file"
         echo "Found $(ls /mnt/${tcrppart}/auxfiles/*pat) file"
         echo "Removing older cached pat files to cache current"


### PR DESCRIPTION
When extending TCRP partition beyond 1GB,
the df call displayed gigabytes instead of megabytes, leading to float comparison not supported by sh.
This caused free space check to fail with an error like "./rploader.sh: line 3191: [: 2.9: integer expression expected". This can be avoided by using -BM flag with df, and removing call to cut.