### PR TITLE
Change build command to a supported model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ A normal build process would start with :
 
 * f. Backup your changes to local loader disk by running `./rploader.sh backup`
 
-### 6. `./rploader.sh build bromolow-7.0.1-42218`
+### 6. `./rploader.sh build ds3615xs-7.0.1-42218`


### PR DESCRIPTION
Hi, the command which is given in README does not work, because it is shown as an unsupported model. I've changed the command to an equivalent one with a working model:
`./rploader.sh build ds3615xs-7.0.1-42218`