### PR TITLE
Update README.md - Add default ssh user/pw

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ A normal build process would start with :
 
 ### 2. Boot tinycore
 
-### 3. ssh to your booted loader or just open the desktop terminal 
+### 3. ssh to your booted loader or just open the desktop terminal
+
+* Hint: Default ssh user: tc / password: P@ssw0rd
 
 ### 4. Bring over your json files (`global_config.json`, `custom_config.json`, `user_config.json`)
 


### PR DESCRIPTION
I just added the default user/pw on the readme page as this is a common question.